### PR TITLE
Feature/code cleanup for clusterers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ client/client
 introducer/introducer
 mainclusterer/mainclusterer
 clusteringnode/clusteringnode
+output.log

--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,7 @@ var nodeItself Node
 func main() {
 	if len(os.Args) != 5 {
 		fmt.Println("format: ./client nodeType introducerIp lat lng")
-		os.Exit(1)
+		os.Exit(0)
 	}
 	clientIp = getMyIp()
 	uuid := uuid.New()
@@ -75,7 +75,6 @@ func acceptClusteringConnections() {
 	address, err := net.ResolveTCPAddr("tcp", "0.0.0.0:"+strconv.Itoa(Ports["client"]))
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 	clientRPC := new(ClientRPC)
 	rpc.Register(clientRPC)

--- a/client/client.go
+++ b/client/client.go
@@ -40,9 +40,9 @@ func main() {
 	req := JoinRequest{NodeRequest: Node{NodeType: nodeType, Ip: clientIp, Uuid: uuid, Lat: lat, Lng: lng}, IntroducerIp: os.Args[2]}
 	r := joinSystem(req)
 	fmt.Println("From Introducer: ", r.Message)
-	// wg.Add(1)
 	acceptClusteringConnections()
-	// wg.Wait()
+
+	// form ring and start bidding
 }
 
 // command called by a client to join the system
@@ -68,7 +68,6 @@ func (c *ClientRPC) RecvClusterInfo(clusterInfo ClusterInfo, response *Response)
 	clusterRep = clusterInfo.ClusterRep
 	clusterNum = clusterInfo.ClusterNum
 	fmt.Println("this client got clusterRep and clusterNum assigned as : ", nodeItself, clusterRep, clusterNum)
-	os.Exit(0)
 	return nil
 }
 

--- a/clusteringNode/clusteringNode.go
+++ b/clusteringNode/clusteringNode.go
@@ -66,12 +66,15 @@ func acceptConnections() {
 func (c *ClusteringNodeRPC) Cluster(request JoinRequest, response *MainClustererClusteringNodeResponse) error {
 	fmt.Println("request from: ", string(request.NodeRequest.Uuid[:]))
 	go ML.Append(request.NodeRequest)
-	fmt.Println("Membership List: ", ML.List)
 	response.Message = "ACK"
 	return nil
 }
 
 func (c *ClusteringNodeRPC) StartClustering(nouse int, response *MainClustererClusteringNodeResponse) error {
+	fmt.Println("Membership List: ")
+	for _, elem := range ML.List {
+		fmt.Print(elem.Uuid, " ")
+	}
 	go func() {
 		coreset := Coreset{}
 

--- a/clusteringNode/clusteringNode.go
+++ b/clusteringNode/clusteringNode.go
@@ -107,13 +107,13 @@ func sendCoreset(coreset Coreset) {
 	conn, err := net.Dial("tcp", mainClustererIp)
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
+		return
 	}
 
 	client := rpc.NewClient(conn)
 	clusterResponse := new(MainClustererClusteringNodeResponse)
 
 	if client.Call("MainClustererRPC.RecvCoreset", coreset, &clusterResponse) != nil {
-		log.Fatal("MainClustererRPC.RecvCoreset error: ", err)
+		os.Stderr.WriteString("MainClustererRPC.RecvCoreset error: " + err.Error())
 	}
 }

--- a/clusteringNode/clusteringNode.go
+++ b/clusteringNode/clusteringNode.go
@@ -73,7 +73,7 @@ func (c *ClusteringNodeRPC) Cluster(request JoinRequest, response *MainClusterer
 func (c *ClusteringNodeRPC) StartClustering(nouse int, response *MainClustererClusteringNodeResponse) error {
 	fmt.Println("Membership List: ")
 	for _, elem := range ML.List {
-		fmt.Print(elem.Uuid, " ")
+		fmt.Print(string(elem.Uuid[:]))
 	}
 	go func() {
 		coreset := Coreset{}

--- a/clusteringNode/clusteringNode.go
+++ b/clusteringNode/clusteringNode.go
@@ -30,24 +30,18 @@ func (m *MembershipList) Clear() {
 	m.mu.Unlock()
 }
 
-func (m *MembershipList) retainOldMembershipList() []Node {
-	m.mu.Lock() // lock membership list and start clustering
-	oldMLList := m.List
-	m.List = nil
-	m.mu.Unlock()
-	return oldMLList
-}
-
 var ip net.IP
 var numClusterNodes = 0
 var ML MembershipList
-var oldML []Node
 
 // VM 2
 var mainClustererIp = "172.22.153.8:" + strconv.Itoa(Ports["mainClusterer"]) // TODO can hard code for now
 
 type ClusteringNodeRPC bool
 
+// accepts connections from main clusterer
+// Cluster: takes cluster request and adds to membership list
+// StartClustering: performs coreset calculation on current membership list. Locks list until done and new requests are queeue'd.
 func main() {
 	acceptConnections()
 }
@@ -71,7 +65,7 @@ func acceptConnections() {
 // get the cluster using the kmeans clustering function and return.
 func (c *ClusteringNodeRPC) Cluster(request JoinRequest, response *MainClustererClusteringNodeResponse) error {
 	fmt.Println("request from: ", string(request.NodeRequest.Uuid[:]))
-	ML.Append(request.NodeRequest)
+	go ML.Append(request.NodeRequest)
 	fmt.Println("Membership List: ", ML.List)
 	response.Message = "ACK"
 	return nil
@@ -80,28 +74,28 @@ func (c *ClusteringNodeRPC) Cluster(request JoinRequest, response *MainClusterer
 func (c *ClusteringNodeRPC) StartClustering(nouse int, response *MainClustererClusteringNodeResponse) error {
 	go func() {
 		coreset := Coreset{}
+
+		// lock list until clustering is done (will still accept new requests which will be added after clsutering)
+		ML.mu.Lock()
 		if len(ML.List) >= NumClusters {
-			oldML = ML.retainOldMembershipList()
 			coreset = kMeansClustering()
+			// clear list after clutsering
+			ML.List = nil
 		}
+		ML.mu.Unlock()
 		// RPC call
 		sendCoreset(coreset)
-
 	}()
 	response.Message = "ACK"
 	return nil
 }
 
 func kMeansClustering() Coreset {
-	// t = clientcount //total number of clients. It should come from mainClusterer.
-	// coreset := IndividualKMeansClustering(ML.List, NumClusters)
-
 	// Calling the centralized K means clustering for current implementation
 	// it returns cluster type and we will create a coreset type from it
 	clusterresult := ClusterResult{}
-	clusterresult = CentralizedKMeansClustering(oldML, NumClusters)
+	clusterresult = CentralizedKMeansClustering(ML.List, NumClusters)
 	coreset := Coreset{Coreset: []Point{}, CoresetNodes: []Node{}, Tempcluster: clusterresult.ClusterMaps}
-
 	return coreset
 }
 

--- a/introducer/introducer.go
+++ b/introducer/introducer.go
@@ -30,14 +30,6 @@ func main() {
 		log.Fatal("listen error:", err)
 	}
 	rpc.Accept(conn)
-
-	// clusterResponse := sendClusteringRPC(0, IntroducerClusterRequest{Uuid: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-	// 	Lat: 23,
-	// 	Lng: 24}) // get assinged clsuter group back
-
-	// // give repsonse to client
-	// r := ClientIntroducerResponse{ClusterNum: clusterResponse.ClusterNum, Error: clusterResponse.Error}
-	// fmt.Println(r.ClusterNum)
 }
 
 // RPC exectued by introducer when new joins occur

--- a/introducer/introducer.go
+++ b/introducer/introducer.go
@@ -45,12 +45,12 @@ func forwardRequestToMainClusterer(request JoinRequest) {
 	conn, err := net.Dial("tcp", mainClustererIp)
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
+		return
 	}
 	client := rpc.NewClient(conn)
 	mainClustererResponse := new(IntroducerMainClustererResponse)
 	err = client.Call("MainClustererRPC.ClusteringRequest", request, &mainClustererResponse)
 	if err != nil {
-		log.Fatal("MainClustererRPC.ClusteringRequest error: ", err)
+		os.Stderr.WriteString("MainClustererRPC.ClusteringRequest error: " + err.Error())
 	}
 }

--- a/mainClusterer/mainClusterer.go
+++ b/mainClusterer/mainClusterer.go
@@ -85,7 +85,6 @@ func acceptConnections() {
 	address, err := net.ResolveTCPAddr("tcp", "0.0.0.0:"+strconv.Itoa(Ports["mainClusterer"]))
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 	mainClustererRPC := new(MainClustererRPC)
 	rpc.Register(mainClustererRPC)
@@ -111,7 +110,7 @@ func sendClusteringRPC(request JoinRequest) {
 	conn, err := net.Dial("tcp", clusteringNodes[clusterNum])
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
+		return
 	}
 
 	client := rpc.NewClient(conn)
@@ -119,7 +118,7 @@ func sendClusteringRPC(request JoinRequest) {
 
 	// send clustering request to clusterNum clustering Node
 	if client.Call("ClusteringNodeRPC.Cluster", request, &clusterResponse) != nil {
-		log.Fatal("ClusteringNodeRPC.Cluster error: ", err)
+		os.Stderr.WriteString("ClusteringNodeRPC.Cluster error: " + err.Error())
 	}
 }
 
@@ -128,7 +127,7 @@ func sendStartClusteringRPC(clusterIp string) {
 	conn, err := net.Dial("tcp", clusterIp)
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
+		return
 	}
 
 	client := rpc.NewClient(conn)
@@ -137,7 +136,7 @@ func sendStartClusteringRPC(clusterIp string) {
 
 	// send start clustering request to clusterNum clustering Node
 	if client.Call("ClusteringNodeRPC.StartClustering", 0, &clusterResponse) != nil {
-		log.Fatal("ClusteringNodeRPC.StartClustering error: ", err)
+		os.Stderr.WriteString("ClusteringNodeRPC.StartClustering error: " + err.Error())
 	}
 }
 
@@ -183,10 +182,10 @@ func sendClusterInfo(node Node, clusterinfo ClusterInfo) {
 	}
 	client := rpc.NewClient(conn)
 	response := new(ClientMainClustererResponse)
-	fmt.Println("Node ", clusterinfo.NodeItself.Uuid, "-> Clsuter ", clusterinfo.ClusterNum, "has cluster rep: ", clusterinfo.ClusterRep.Uuid)
+	fmt.Println("Node ", string(clusterinfo.NodeItself.Uuid[:]), "-> Clsuter ", clusterinfo.ClusterNum, "has cluster rep: ", string(clusterinfo.ClusterRep.Uuid[:]))
 
 	err = client.Call("ClientRPC.RecvClusterInfo", clusterinfo, &response)
 	if err != nil {
-		log.Fatal("IntroducerRPC.ClientJoin error: ", err)
+		os.Stderr.WriteString("IntroducerRPC.ClientJoin error: " + err.Error())
 	}
 }

--- a/mainClusterer/mainClusterer.go
+++ b/mainClusterer/mainClusterer.go
@@ -97,7 +97,6 @@ func acceptConnections() {
 }
 
 func (m *MainClustererRPC) ClusteringRequest(request JoinRequest, response *IntroducerMainClustererResponse) error {
-	fmt.Println("hello")
 	go sendClusteringRPC(request)
 	response.Message = "ACK"
 	return nil

--- a/mainClusterer/mainClusterer.go
+++ b/mainClusterer/mainClusterer.go
@@ -179,7 +179,7 @@ func sendClusterInfo(node Node, clusterinfo ClusterInfo) {
 	conn, err := net.Dial("tcp", node.Ip)
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
-		os.Exit(1)
+		return
 	}
 	client := rpc.NewClient(conn)
 	response := new(ClientMainClustererResponse)

--- a/mainClusterer/mainClusterer.go
+++ b/mainClusterer/mainClusterer.go
@@ -183,7 +183,7 @@ func sendClusterInfo(node Node, clusterinfo ClusterInfo) {
 	}
 	client := rpc.NewClient(conn)
 	response := new(ClientMainClustererResponse)
-	fmt.Println("send this clusterRep and clusterNum from main: ", clusterinfo)
+	fmt.Println("Node ", clusterinfo.NodeItself.Uuid, "-> Clsuter ", clusterinfo.ClusterNum, "has cluster rep: ", clusterinfo.ClusterRep.Uuid)
 
 	err = client.Call("ClientRPC.RecvClusterInfo", clusterinfo, &response)
 	if err != nil {


### PR DESCRIPTION
- code cleanup 
- remove log.fatals() where not actually fatal 
- remove temp lists from clusteringnode and main clusterer and replace with go routine 